### PR TITLE
Fix: Error: Cannot find module '../dist/minify-geojson-cli'

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,4 +1,4 @@
 #! /usr/bin/env node
 
-var minifygeojson = require('../dist/minify-geojson-cli');
+var minifygeojson = require('../dist/cli');
 minifygeojson

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "minify-geojson",
   "version": "1.4.0",
   "description": "Minify (compress) a GeoJSON by replacing the attribute keys with a shorter representation (typically, its first letter). You can also reduce the number of decimals for coordinates, and whitelist and blacklist certain properties.",
-  "main": "./dist/minify-geojson-cli.js",
-  "types": "./dist/minify-geojson-cli.d.ts",
+  "main": "./dist/cli.js",
+  "types": "./dist/cli.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/TNOCS/minify-geojson.git"


### PR DESCRIPTION
Hi, :)

running 

`minify-geojson -c 5 .\world.json` gives the error

```
internal/modules/cjs/loader.js:775
    throw err;
    ^

Error: Cannot find module '../dist/minify-geojson-cli'
Require stack:
- C:\Users\username\AppData\Roaming\npm\node_modules\minify-geojson\bin\run.js
```